### PR TITLE
DebugTrace + No autowiring of nullables

### DIFF
--- a/src/Container/Exceptions/ContainerException.php
+++ b/src/Container/Exceptions/ContainerException.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Maduser\Argon\Container\Exceptions;
 
 use Exception;
+use Maduser\Argon\Container\Support\DebugTrace;
 use Psr\Container\ContainerExceptionInterface;
 use Throwable;
 
@@ -15,20 +16,20 @@ final class ContainerException extends Exception implements ContainerExceptionIn
 {
     public static function fromServiceId(string $id, string $message): self
     {
-        return new self("Error with service '$id': $message");
+        return new self("Error with service '$id': $message" . self::appendTrace());
     }
 
     public static function forNonInstantiableClass(string $serviceId, string $className): self
     {
         return new self(
-            "Class '$className' (requested as '$serviceId') is not instantiable."
+            "Class '$className' (requested as '$serviceId') is not instantiable." . self::appendTrace()
         );
     }
 
     public static function forUnresolvedPrimitive(string $className, string $paramName): self
     {
         return new self(
-            "Cannot resolve primitive parameter '$paramName' in service '$className'."
+            "Cannot resolve primitive parameter '$paramName' in service '$className'." . self::appendTrace()
         );
     }
 
@@ -41,21 +42,21 @@ final class ContainerException extends Exception implements ContainerExceptionIn
     {
         $chain = implode(' -> ', $dependencyChain);
         return new self(
-            "Circular dependency detected for service '$serviceId'. Chain: $chain"
+            "Circular dependency detected for service '$serviceId'. Chain: $chain" . self::appendTrace()
         );
     }
 
     public static function forUnresolvableDependency(string $className, string $paramName): self
     {
         return new self(
-            "Unresolvable dependency '$paramName' in service '$className'."
+            "Unresolvable dependency '$paramName' in service '$className'." . self::appendTrace()
         );
     }
 
-    public static function forInstantiationFailure(string $className, \Throwable $previous): self
+    public static function forInstantiationFailure(string $className, Throwable $previous): self
     {
         return new self(
-            "Failed to instantiate '$className' with resolved dependencies.",
+            "Failed to instantiate '$className' with resolved dependencies." . self::appendTrace(),
             0,
             $previous
         );
@@ -63,6 +64,12 @@ final class ContainerException extends Exception implements ContainerExceptionIn
 
     public static function fromInterceptor(string $interceptor, string $message): self
     {
-        return new self("[$interceptor] $message");
+        return new self("[$interceptor] $message" . self::appendTrace());
+    }
+
+    private static function appendTrace(): string
+    {
+        $trace = DebugTrace::toJson();
+        return $trace !== '{}' ? "\n\nDebugTrace:\n$trace" : '';
     }
 }

--- a/src/Container/Exceptions/NotFoundException.php
+++ b/src/Container/Exceptions/NotFoundException.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Maduser\Argon\Container\Exceptions;
 
 use Exception;
+use Maduser\Argon\Container\Support\DebugTrace;
 use Psr\Container\NotFoundExceptionInterface;
 
 /**
@@ -12,8 +13,9 @@ use Psr\Container\NotFoundExceptionInterface;
  */
 final class NotFoundException extends Exception implements NotFoundExceptionInterface
 {
-    public function __construct(string $serviceId)
+    public function __construct(string $serviceId, string $requestedBy = 'unknown')
     {
-        parent::__construct("Service '$serviceId' not found.", 404);
+        $message = "Service '$serviceId' not found (requested by $requestedBy).";
+        parent::__construct($message, 404);
     }
 }

--- a/src/Container/Support/DebugTrace.php
+++ b/src/Container/Support/DebugTrace.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Maduser\Argon\Container\Support;
+
+final class DebugTrace
+{
+    /**
+     * @var array<string, array<string, array{expected: string, received?: string, error?: string, resolved?: array}>>
+     */
+    private static array $trace = [];
+
+    public static function reset(): void
+    {
+        self::$trace = [];
+    }
+
+    public static function add(string $className, string $paramName, string $expectedType, mixed $value): void
+    {
+        self::$trace[$className][$paramName] = [
+            'expected' => $expectedType,
+            'received' => match (true) {
+                is_object($value) => get_class($value),
+                is_string($value) && class_exists($value) => $value . ' (class-string)',
+                default => gettype($value)
+            }
+        ];
+    }
+
+    public static function fail(string $className, string $paramName, string $expectedType): void
+    {
+        self::$trace[$className][$paramName] = [
+            'expected' => $expectedType,
+            'error' => 'unresolved'
+        ];
+    }
+
+    public static function nest(string $parentClass, string $paramName, array $subtrace): void
+    {
+        if (!isset(self::$trace[$parentClass][$paramName])) {
+            self::$trace[$parentClass][$paramName] = [];
+        }
+
+        self::$trace[$parentClass][$paramName]['resolved'] = $subtrace;
+    }
+
+    public static function get(): array
+    {
+        return self::$trace;
+    }
+
+    public static function dump(): array
+    {
+        return self::$trace;
+    }
+
+    public static function hasErrors(): bool
+    {
+        foreach (self::$trace as $params) {
+            foreach ($params as $info) {
+                if (isset($info['error']) || ($info['received'] ?? null) === 'NULL') {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    public static function toJson(): string
+    {
+        return json_encode(self::$trace, JSON_PRETTY_PRINT);
+    }
+}

--- a/tests/integration/AutowiringTest.php
+++ b/tests/integration/AutowiringTest.php
@@ -85,10 +85,26 @@ final class AutowiringTest extends TestCase
      * @throws ContainerException
      * @throws NotFoundException
      */
-    public function testNullableDependencyGetsResolvedIfResolvable(): void
+    public function testOptionalNullableDependencyStaysNull(): void
     {
         $container = new ArgonContainer();
+
         $instance = $container->get(NeedsNullable::class);
+
+        $this->assertNull($instance->logger);
+    }
+
+    /**
+     * @throws ContainerException
+     * @throws NotFoundException
+     */
+    public function testNullableDependencyGetsResolvedWhenBound(): void
+    {
+        $container = new ArgonContainer();
+
+        $instance = $container->get(NeedsNullable::class, args: [
+            'logger' => Logger::class,
+        ]);
 
         $this->assertInstanceOf(Logger::class, $instance->logger);
     }

--- a/tests/integration/Compiler/Mocks/ImplicitNullable.php
+++ b/tests/integration/Compiler/Mocks/ImplicitNullable.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Compiler\Mocks;
+
+use Tests\Integration\Mocks\LoggerInterface;
+
+class ImplicitNullable
+{
+    public ?LoggerInterface $logger;
+
+    public function __construct(?LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+}

--- a/tests/integration/Compiler/Mocks/Logger.php
+++ b/tests/integration/Compiler/Mocks/Logger.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Compiler\Mocks;
 
-class Logger
+use Tests\Integration\Mocks\LoggerInterface;
+
+class Logger implements LoggerInterface
 {
     public bool $intercepted = false;
 

--- a/tests/integration/Compiler/Mocks/WithOptionalInterface.php
+++ b/tests/integration/Compiler/Mocks/WithOptionalInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Compiler\Mocks;
+
+use Tests\Integration\Mocks\LoggerInterface;
+
+class WithOptionalInterface
+{
+    public ?LoggerInterface $logger = null;
+    public function __construct(
+        ?LoggerInterface $logger = null
+    ) {
+        $this->logger = $logger;
+    }
+}

--- a/tests/integration/Compiler/Mocks/WithOptionalService.php
+++ b/tests/integration/Compiler/Mocks/WithOptionalService.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Compiler\Mocks;
+
+class WithOptionalService
+{
+    public ?Logger $logger = null;
+    public function __construct(
+        ?Logger $logger = null
+    ) {
+        $this->logger = $logger;
+    }
+}

--- a/tests/unit/Container/Compiler/Mocks/DummyBindings.php
+++ b/tests/unit/Container/Compiler/Mocks/DummyBindings.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Container\Compiler\Mocks;
+
+final class DummyBindings
+{
+    public function __construct(private array $bindings = [])
+    {
+    }
+
+    public function has(string $context, string $type): bool
+    {
+        return isset($this->bindings[$context][$type]);
+    }
+
+    public function get(string $context, string $type): string
+    {
+        return $this->bindings[$context][$type];
+    }
+}

--- a/tests/unit/Container/Compiler/Mocks/DummyBindings.php
+++ b/tests/unit/Container/Compiler/Mocks/DummyBindings.php
@@ -4,10 +4,14 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Container\Compiler\Mocks;
 
-final class DummyBindings
+final readonly class DummyBindings
 {
-    public function __construct(private array $bindings = [])
-    {
+    public function __construct(
+        /**
+         * @var array<array-key, array<array-key, string>>
+         */
+        private array $bindings = []
+    ) {
     }
 
     public function has(string $context, string $type): bool

--- a/tests/unit/Container/Compiler/Mocks/DummyContainer.php
+++ b/tests/unit/Container/Compiler/Mocks/DummyContainer.php
@@ -14,11 +14,18 @@ final class DummyContainer
         return in_array($id, $this->hasServices, true);
     }
 
+    /**
+     * @psalm-suppress UnusedParam $serviceId
+     */
     public function getDescriptor(string $serviceId): ?object
     {
         return new class ($this->descriptorArgs) {
-            public function __construct(private array $args)
-            {
+            public function __construct(
+                /**
+                 * @var array<array-key, mixed>
+                 */
+                private readonly array $args
+            ) {
             }
 
             public function hasArgument(string $key): bool
@@ -33,7 +40,7 @@ final class DummyContainer
         };
     }
 
-    public function get(string $id): object
+    public function get(): object
     {
         return new \stdClass();
     }

--- a/tests/unit/Container/Compiler/Mocks/DummyContainer.php
+++ b/tests/unit/Container/Compiler/Mocks/DummyContainer.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Container\Compiler\Mocks;
+
+final class DummyContainer
+{
+    public array $hasServices = [];
+    public array $descriptorArgs = [];
+
+    public function has(string $id): bool
+    {
+        return in_array($id, $this->hasServices, true);
+    }
+
+    public function getDescriptor(string $serviceId): ?object
+    {
+        return new class ($this->descriptorArgs) {
+            public function __construct(private array $args)
+            {
+            }
+
+            public function hasArgument(string $key): bool
+            {
+                return array_key_exists($key, $this->args);
+            }
+
+            public function getArgument(string $key): mixed
+            {
+                return $this->args[$key] ?? null;
+            }
+        };
+    }
+
+    public function get(string $id): object
+    {
+        return new \stdClass();
+    }
+}

--- a/tests/unit/Container/Compiler/Mocks/FakeResolver.php
+++ b/tests/unit/Container/Compiler/Mocks/FakeResolver.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Container\Compiler\Mocks;
+
+use ReflectionNamedType;
+use ReflectionParameter;
+
+final class FakeResolver
+{
+    public DummyContainer $container;
+    public DummyBindings $contextualBindings;
+
+    public function __construct(array $bindings = [])
+    {
+        $this->container = new DummyContainer();
+        $this->contextualBindings = new DummyBindings($bindings);
+    }
+
+    public function resolveParameter(
+        ReflectionParameter $parameter,
+        string $serviceId,
+        string $argsVar = '$args'
+    ): string {
+        $name = $parameter->getName();
+        $type = $parameter->getType();
+        $typeName = $type instanceof ReflectionNamedType ? $type->getName() : null;
+
+        $runtime = "{$argsVar}[" . var_export($name, true) . "]";
+        $fallbacks = [];
+        $declaringClass = $parameter->getDeclaringClass();
+        $context = $declaringClass?->getName() ?? $serviceId;
+
+        // Contextual binding
+        if ($typeName !== null && $this->contextualBindings->has($context, $typeName)) {
+            $target = $this->contextualBindings->get($context, $typeName);
+            if (is_string($target)) {
+                $fallbacks[] = "\$this->get('{$target}')";
+            }
+        }
+
+        // Registered service
+        if ($typeName !== null && $this->container->has($typeName)) {
+            $fallbacks[] = "\$this->get('{$typeName}')";
+        }
+
+        // Explicit descriptor argument
+        if ($this->container->getDescriptor($serviceId)?->hasArgument($name)) {
+            /**
+             * @var null|bool|int|float|string|array|object $value
+             */
+            $value = $this->container->getDescriptor($serviceId)?->getArgument($name);
+
+            if (
+                is_string($value) &&
+                $type instanceof ReflectionNamedType &&
+                !$type->isBuiltin() &&
+                class_exists($value)
+            ) {
+                $fallbacks[] = "\$this->get('{$value}')";
+            } else {
+                $fallbacks[] = var_export($value, true);
+            }
+        }
+
+        // Method default value
+        if ($parameter->isDefaultValueAvailable()) {
+            $fallbacks[] = var_export($parameter->getDefaultValue(), true);
+        }
+
+        // Fallback to null ONLY if no viable candidate exists and nullable
+        if (
+            empty($fallbacks) &&
+            $type instanceof ReflectionNamedType &&
+            $type->allowsNull()
+        ) {
+            $fallbacks[] = 'null';
+        }
+
+        // Final fallback chain
+        if (!empty($fallbacks)) {
+            return $runtime . ' ?? ' . implode(' ?? ', $fallbacks);
+        }
+
+        // No fallbacks—return raw
+        return $runtime;
+    }
+}

--- a/tests/unit/Container/Compiler/Mocks/FakeResolver.php
+++ b/tests/unit/Container/Compiler/Mocks/FakeResolver.php
@@ -12,9 +12,14 @@ final class FakeResolver
     public DummyContainer $container;
     public DummyBindings $contextualBindings;
 
-    public function __construct(array $bindings = [])
-    {
+    /**
+     * @param  array<array-key, array<array-key, string>> $bindings
+     */
+    public function __construct(
+        array $bindings = []
+    ) {
         $this->container = new DummyContainer();
+
         $this->contextualBindings = new DummyBindings($bindings);
     }
 
@@ -35,9 +40,7 @@ final class FakeResolver
         // Contextual binding
         if ($typeName !== null && $this->contextualBindings->has($context, $typeName)) {
             $target = $this->contextualBindings->get($context, $typeName);
-            if (is_string($target)) {
-                $fallbacks[] = "\$this->get('{$target}')";
-            }
+            $fallbacks[] = "\$this->get('{$target}')";
         }
 
         // Registered service
@@ -46,7 +49,10 @@ final class FakeResolver
         }
 
         // Explicit descriptor argument
-        if ($this->container->getDescriptor($serviceId)?->hasArgument($name)) {
+        $descriptor = $this->container->getDescriptor($serviceId);
+
+
+        if ($descriptor !== null && $descriptor->hasArgument($name)) {
             /**
              * @var null|bool|int|float|string|array|object $value
              */

--- a/tests/unit/Container/Compiler/ParameterResolverTest.php
+++ b/tests/unit/Container/Compiler/ParameterResolverTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Container\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionNamedType;
+use ReflectionParameter;
+use Tests\Integration\Mocks\Logger;
+use Tests\Mocks\LoggerInterface;
+use Tests\Unit\Container\Compiler\Mocks\FakeResolver;
+
+final class ParameterResolverTest extends TestCase
+{
+    public function testReturnsArgumentAccessWhenNoFallbacks(): void
+    {
+        $param = $this->makeParameterMock('id', allowsNull: false, hasDefault: false);
+        $resolver = new FakeResolver();
+
+        $code = $resolver->resolveParameter($param, 'SomeService');
+        $this->assertSame('$args[\'id\']', $code);
+    }
+
+    public function testReturnsNullFallbackIfAllowedAndNothingElse(): void
+    {
+        $param = $this->makeParameterMock('logger', allowsNull: true, hasDefault: false);
+        $resolver = new FakeResolver();
+
+        $code = $resolver->resolveParameter($param, 'NoBindings');
+        $this->assertSame('$args[\'logger\'] ?? null', $code);
+    }
+
+    public function testUsesContextualBindingIfAvailable(): void
+    {
+        $param = $this->makeParameterMock('service', LoggerInterface::class);
+        $resolver = new FakeResolver(['SomeService' => [
+            LoggerInterface::class => Logger::class
+        ]]);
+
+        $code = $resolver->resolveParameter($param, 'SomeService');
+        $this->assertSame('$args[\'service\'] ?? $this->get(\'Tests\Integration\Mocks\Logger\')', $code);
+    }
+
+    public function testUsesContainerIfServiceExists(): void
+    {
+        $param = $this->makeParameterMock('logger', Logger::class);
+        $resolver = new FakeResolver();
+        $resolver->container->hasServices[] = Logger::class;
+
+        $code = $resolver->resolveParameter($param, 'AnyService');
+        $this->assertSame('$args[\'logger\'] ?? $this->get(\'' . Logger::class . '\')', $code);
+    }
+
+    public function testResolvesDescriptorArgumentValue(): void
+    {
+        $param = $this->makeParameterMock('foo', allowsNull: false, hasDefault: false);
+        $resolver = new FakeResolver();
+        $resolver->container->descriptorArgs = ['foo' => 123];
+
+        $code = $resolver->resolveParameter($param, 'ServiceId');
+        $this->assertSame('$args[\'foo\'] ?? 123', $code);
+    }
+
+    public function testResolvesDescriptorArgumentAsClass(): void
+    {
+        $param = $this->makeParameterMock('foo', Logger::class, isBuiltin: false);
+        $resolver = new FakeResolver();
+        $resolver->container->descriptorArgs = ['foo' => Logger::class];
+
+        $code = $resolver->resolveParameter($param, 'ServiceId');
+        $this->assertSame('$args[\'foo\'] ?? $this->get(\'' . Logger::class . '\')', $code);
+    }
+
+    public function testReturnsDefaultValue(): void
+    {
+        $param = $this->makeParameterMock('foo', hasDefault: true, defaultValue: 'default');
+        $resolver = new FakeResolver();
+
+        $code = $resolver->resolveParameter($param, 'ServiceId');
+        $this->assertSame('$args[\'foo\'] ?? \'default\'', $code);
+    }
+
+    // === Helpers ===
+
+    private function makeParameterMock(
+        string $name,
+        string $typeName = 'string',
+        bool $allowsNull = false,
+        bool $isBuiltin = true,
+        bool $hasDefault = false,
+        mixed $defaultValue = null
+    ): ReflectionParameter {
+        $type = $this->createMock(ReflectionNamedType::class);
+        $type->method('getName')->willReturn($typeName);
+        $type->method('allowsNull')->willReturn($allowsNull);
+        $type->method('isBuiltin')->willReturn($isBuiltin);
+
+        $param = $this->createMock(ReflectionParameter::class);
+        $param->method('getName')->willReturn($name);
+        $param->method('getType')->willReturn($type);
+        $param->method('getDeclaringClass')->willReturn(null);
+        $param->method('isDefaultValueAvailable')->willReturn($hasDefault);
+        if ($hasDefault) {
+            $param->method('getDefaultValue')->willReturn($defaultValue);
+        }
+
+        return $param;
+    }
+}

--- a/tests/unit/Container/ServiceContainerTest.php
+++ b/tests/unit/Container/ServiceContainerTest.php
@@ -464,7 +464,7 @@ class ServiceContainerTest extends TestCase
 
         // Expect a NotFoundException for the missing dependency class
         $this->expectException(NotFoundException::class);
-        $this->expectExceptionMessage("Service 'Tests\\Mocks\\NonExistentDependency' not found.");
+        $this->expectExceptionMessageMatches('/Service .* not found./');
 
         // Trigger the exception by attempting to resolve the service
         $container->get(TestServiceWithNonExistentDependency::class);

--- a/tests/unit/Container/Support/DebugTraceTest.php
+++ b/tests/unit/Container/Support/DebugTraceTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Container\Support;
+
+use PHPUnit\Framework\TestCase;
+use Maduser\Argon\Container\Support\DebugTrace;
+
+final class DebugTraceTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        DebugTrace::reset();
+    }
+
+    public function testAddWithObject(): void
+    {
+        $value = new \stdClass();
+        DebugTrace::add('TestClass', 'param', 'stdClass', $value);
+
+        $trace = DebugTrace::get();
+
+        $this->assertSame('stdClass', $trace['TestClass']['param']['received']);
+        $this->assertSame('stdClass', $trace['TestClass']['param']['expected']);
+    }
+
+    public function testAddWithClassString(): void
+    {
+        $value = \stdClass::class;
+        DebugTrace::add('TestClass', 'param', 'class-string', $value);
+
+        $trace = DebugTrace::get();
+
+        $this->assertSame('stdClass (class-string)', $trace['TestClass']['param']['received']);
+        $this->assertSame('class-string', $trace['TestClass']['param']['expected']);
+    }
+
+    public function testAddWithScalar(): void
+    {
+        DebugTrace::add('TestClass', 'param', 'int', 42);
+
+        $trace = DebugTrace::get();
+
+        $this->assertSame('integer', $trace['TestClass']['param']['received']);
+        $this->assertSame('int', $trace['TestClass']['param']['expected']);
+    }
+
+    public function testFail(): void
+    {
+        DebugTrace::fail('TestClass', 'param', 'string');
+
+        $trace = DebugTrace::get();
+
+        $this->assertSame('string', $trace['TestClass']['param']['expected']);
+        $this->assertSame('unresolved', $trace['TestClass']['param']['error']);
+    }
+
+    public function testNestCreatesResolved(): void
+    {
+        DebugTrace::add('TestClass', 'param', 'array', []);
+        DebugTrace::nest('TestClass', 'param', ['nested' => ['expected' => 'int']]);
+
+        $trace = DebugTrace::get();
+
+        $this->assertArrayHasKey('resolved', $trace['TestClass']['param']);
+        $this->assertSame(['nested' => ['expected' => 'int']], $trace['TestClass']['param']['resolved']);
+    }
+
+    public function testNestOnUninitialized(): void
+    {
+        DebugTrace::nest('AnotherClass', 'anotherParam', ['foo' => ['expected' => 'bar']]);
+
+        $trace = DebugTrace::get();
+
+        $this->assertArrayHasKey('resolved', $trace['AnotherClass']['anotherParam']);
+        $this->assertSame(['foo' => ['expected' => 'bar']], $trace['AnotherClass']['anotherParam']['resolved']);
+    }
+
+    public function testHasErrorsReturnsTrueOnError(): void
+    {
+        DebugTrace::fail('TestClass', 'param', 'string');
+        $this->assertTrue(DebugTrace::hasErrors());
+    }
+
+    public function testHasErrorsReturnsTrueOnNull(): void
+    {
+        DebugTrace::add('TestClass', 'param', 'string', null);
+        $this->assertTrue(DebugTrace::hasErrors());
+    }
+
+    public function testHasErrorsReturnsFalse(): void
+    {
+        DebugTrace::add('TestClass', 'param', 'string', 'value');
+        $this->assertFalse(DebugTrace::hasErrors());
+    }
+
+    public function testDumpReturnsTrace(): void
+    {
+        DebugTrace::add('TestClass', 'param', 'string', 'value');
+        $this->assertSame(DebugTrace::get(), DebugTrace::dump());
+    }
+
+    public function testToJson(): void
+    {
+        DebugTrace::add('TestClass', 'param', 'string', 'value');
+        $json = DebugTrace::toJson();
+
+        $this->assertJson($json);
+        $this->assertStringContainsString('"expected": "string"', $json);
+    }
+
+    public function testResetClearsTrace(): void
+    {
+        DebugTrace::add('TestClass', 'param', 'string', 'value');
+        DebugTrace::reset();
+
+        $this->assertSame([], DebugTrace::get());
+    }
+}


### PR DESCRIPTION
DebugTrace + No autowiring of nullables
- Implement DebugTrace to trace nested resolutions
- Nullables are no longer autowired
- Respect implicit nullables
- Compiler now also correctly supports class-strings as resolvable arguments