### PR TITLE
Fix resolver cleanup after failed resolutions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to `maduser/argon` will be documented in this file.
 ### Fixed
 
 - Runtime resolution now clears the circular-dependency guard after failed resolutions, preventing repeated failures from being misreported as circular dependencies.
+- `extend()` API documentation now matches its existing resolve-then-decorate behavior.
 
 ## [1.1.0] - 2026-05-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `maduser/argon` will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- Runtime resolution now clears the circular-dependency guard after failed resolutions, preventing repeated failures from being misreported as circular dependencies.
+
 ## [1.1.0] - 2026-05-20
 
 ### Changed

--- a/readme.md
+++ b/readme.md
@@ -481,7 +481,7 @@ The compiled container is a pure PHP class with zero runtime resolution logic fo
 | `getTags()`               | –                                               | `array<string, list<string>>`              | Returns all tag definitions in the container.                                     |
 | `getTagged()`             | `string $tag`                                   | `list<object>`                             | Resolves all services tagged with the given label.                                |
 | `boot()`                  | –                                               | `ArgonContainer`                           | Bootstraps all registered service providers.                                      |
-| `extend()`                | `string $id`  `callable $decorator`             | `ArgonContainer`                           | Decorates an already-resolved service at runtime.                                 |
+| `extend()`                | `string $id`  `callable $decorator`             | `ArgonContainer`                           | Resolves then decorates a service, replacing the binding for future resolutions.  |
 | `for()`                   | `string $target`                                | `ContextualBindingBuilder`                 | Begins a contextual binding chain — call `->set()` to define per-target bindings. |
 | `getPreInterceptors()`    | –                                               | `list<class-string<InterceptorInterface>>` | Lists all registered pre-interceptors.                                            |
 | `getPostInterceptors()`   | –                                               | `list<class-string<InterceptorInterface>>` | Lists all registered post-interceptors.                                           |

--- a/src/ArgonContainer.php
+++ b/src/ArgonContainer.php
@@ -294,10 +294,10 @@ class ArgonContainer implements ContainerInterface
     }
 
     /**
-     * Extends an already-resolved service at runtime.
+     * Resolves and decorates a service at runtime.
      *
-     * This method only works after the service has been resolved.
-     * It should be called during `boot()` or runtime setup — not `register()`.
+     * The service is resolved through get(), passed to the decorator, and then
+     * replaced by the decorated instance for later resolutions.
      *
      * @template T of object
      * @param class-string<T>|string $id

--- a/src/ServiceResolver.php
+++ b/src/ServiceResolver.php
@@ -79,7 +79,6 @@ final class ServiceResolver implements ServiceResolverInterface
         try {
             $result = $this->interceptors->matchPre($id, $args);
             if ($result !== null) {
-                $this->removeFromResolving($id);
                 return $result;
             }
 
@@ -94,15 +93,14 @@ final class ServiceResolver implements ServiceResolverInterface
                 throw new NotFoundException($id, $requestedBy);
             }
 
-            $this->removeFromResolving($id);
             return $instance;
         } catch (ReflectionException $e) {
-            $this->removeFromResolving($id);
             throw ContainerException::fromServiceId(
                 $id,
                 'Reflection error: ' . $e->getMessage()
             );
         } finally {
+            $this->removeFromResolving($id);
             array_pop(self::$resolutionStack);
         }
     }

--- a/tests/unit/Container/ServiceResolverTest.php
+++ b/tests/unit/Container/ServiceResolverTest.php
@@ -117,6 +117,26 @@ final class ServiceResolverTest extends TestCase
     }
 
     /**
+     * @throws ContainerException
+     */
+    public function testFailedResolutionDoesNotPoisonCircularDependencyGuard(): void
+    {
+        $this->binder->method('getDescriptor')->willReturn(null);
+
+        for ($attempt = 1; $attempt <= 2; $attempt++) {
+            try {
+                $this->resolver->resolve('NonExistentService');
+                $this->fail('Expected resolution to fail.');
+            } catch (NotFoundException $exception) {
+                $this->assertSame(
+                    "Service 'NonExistentService' not found (requested by unknown).",
+                    strtok($exception->getMessage(), "\n")
+                );
+            }
+        }
+    }
+
+    /**
      * @throws NotFoundException
      */
     public function testThrowsForNonInstantiableClass(): void


### PR DESCRIPTION
## Summary

- Clear the runtime resolver's circular-dependency guard for all resolution exit paths, including `NotFoundException` and other container failures.
- Add a regression test proving repeated failed resolutions keep reporting the original failure instead of a false circular dependency.
- Align `extend()` API-level docs with the existing resolve-then-decorate runtime behavior.
- Update `CHANGELOG.md` under `Unreleased`.

## Validation

- `vendor/bin/phpunit tests/unit/Container/ServiceResolverTest.php`
- `composer check`

Closes #45
Closes #46