### PR TITLE
Prepare Argon 1.1.2 patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to `maduser/argon` will be documented in this file.
 
 ### Fixed
 
+- Runtime resolution now detects circular alias chains while following class aliases.
 - `registerInterceptor()` now rejects classes that implement neither pre- nor post-resolution interceptor contracts.
 - `ParameterStore::get()` now preserves explicitly stored `null` values when a default value is provided.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to `maduser/argon` will be documented in this file.
 
 ### Fixed
 
+- `registerInterceptor()` now rejects classes that implement neither pre- nor post-resolution interceptor contracts.
 - `ParameterStore::get()` now preserves explicitly stored `null` values when a default value is provided.
 
 ## [1.1.1] - 2026-05-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to `maduser/argon` will be documented in this file.
 
 ### Fixed
 
+- `ParameterStore::get()` now preserves explicitly stored `null` values when a default value is provided.
+
+## [1.1.1] - 2026-05-20
+
+### Fixed
+
 - Runtime resolution now clears the circular-dependency guard after failed resolutions, preventing repeated failures from being misreported as circular dependencies.
 - `extend()` API documentation now matches its existing resolve-then-decorate behavior.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to `maduser/argon` will be documented in this file.
 
-## [Unreleased]
+## [1.1.2] - 2026-05-21
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to `maduser/argon` will be documented in this file.
 
 ### Fixed
 
+- `ContainerCompiler::compile()` now distinguishes omitted strict mode from an explicit `false` value.
 - Runtime resolution now detects circular alias chains while following class aliases.
 - `registerInterceptor()` now rejects classes that implement neither pre- nor post-resolution interceptor contracts.
 - `ParameterStore::get()` now preserves explicitly stored `null` values when a default value is provided.

--- a/readme.md
+++ b/readme.md
@@ -464,6 +464,9 @@ if (file_exists($file) && !$_ENV['DEV']) {
 ```
 The compiled container is a pure PHP class with zero runtime resolution logic for standard bindings. In **strict mode** the generated class omits the dynamic fallback entirely—missing registrations fail fast with `NotFoundException`. In magic mode it continues to fall back to the runtime resolver when needed.
 
+When `strictMode` is omitted, the compiler mirrors the source container's current strict-mode setting. Pass
+`strictMode: false` explicitly to force a lenient compiled container from a strict runtime container.
+
 ## `ArgonContainer` API
 
 | ArgonContainer            | Parameters                                      | Return                                     | Description                                                                       |

--- a/src/ArgonContainer.php
+++ b/src/ArgonContainer.php
@@ -219,12 +219,27 @@ class ArgonContainer implements ContainerInterface
             );
         }
 
-        if (is_subclass_of($interceptorClass, PreResolutionInterceptorInterface::class)) {
-            $this->interceptors->registerPre($interceptorClass);
+        $isPreInterceptor = is_subclass_of($interceptorClass, PreResolutionInterceptorInterface::class);
+        $isPostInterceptor = is_subclass_of($interceptorClass, PostResolutionInterceptorInterface::class);
+
+        if (!$isPreInterceptor && !$isPostInterceptor) {
+            throw ContainerException::fromInterceptor(
+                $interceptorClass,
+                "Interceptor '$interceptorClass' must implement PreResolutionInterceptorInterface " .
+                'or PostResolutionInterceptorInterface.'
+            );
         }
 
-        if (is_subclass_of($interceptorClass, PostResolutionInterceptorInterface::class)) {
-            $this->interceptors->registerPost($interceptorClass);
+        if ($isPreInterceptor) {
+            /** @var class-string<PreResolutionInterceptorInterface> $preInterceptorClass */
+            $preInterceptorClass = $interceptorClass;
+            $this->interceptors->registerPre($preInterceptorClass);
+        }
+
+        if ($isPostInterceptor) {
+            /** @var class-string<PostResolutionInterceptorInterface> $postInterceptorClass */
+            $postInterceptorClass = $interceptorClass;
+            $this->interceptors->registerPost($postInterceptorClass);
         }
 
         return $this;

--- a/src/Compiler/ContainerCompiler.php
+++ b/src/Compiler/ContainerCompiler.php
@@ -46,9 +46,9 @@ final class ContainerCompiler
         string $filePath,
         string $className,
         string $namespace = 'App\\Compiled',
-        bool $strictMode = false
+        ?bool $strictMode = null
     ): void {
-        if (!$strictMode) {
+        if ($strictMode === null) {
             $strictMode = $this->container->isStrictMode();
         }
 

--- a/src/ParameterStore.php
+++ b/src/ParameterStore.php
@@ -26,7 +26,7 @@ final class ParameterStore implements ParameterStoreInterface
     #[Override]
     public function get(string $key, int|string|bool|null $default = null): mixed
     {
-        return $this->store[$key] ?? $default;
+        return array_key_exists($key, $this->store) ? $this->store[$key] : $default;
     }
 
     #[Override]

--- a/src/ServiceResolver.php
+++ b/src/ServiceResolver.php
@@ -135,7 +135,7 @@ final class ServiceResolver implements ServiceResolverInterface
 
             $instance = $concrete instanceof Closure
                 ? $this->resolveClosure($concrete, $args, $id)
-                : $this->resolveClass($concrete, $args);
+                : $this->resolveClass($concrete, $args, $concrete === $id ? [] : [$id]);
         }
 
         $instance = $this->interceptors->matchPost($instance);
@@ -210,14 +210,19 @@ final class ServiceResolver implements ServiceResolverInterface
      * @template T of object
      * @param class-string<T> $className
      * @param array<array-key, mixed> $args
+     * @param list<string> $aliasChain
      * @return object|null
      * @psalm-return ($className is class-string<T> ? T : object)
      *
      * @throws ContainerException
      * @throws NotFoundException
      */
-    private function resolveClass(string $className, array $args = []): ?object
+    private function resolveClass(string $className, array $args = [], array $aliasChain = []): ?object
     {
+        if (in_array($className, $aliasChain, true)) {
+            throw ContainerException::forCircularDependency($className, [...$aliasChain, $className]);
+        }
+
         if ($descriptor = $this->binder->getDescriptor($className)) {
             $concrete = $descriptor->getConcrete();
 
@@ -227,7 +232,7 @@ final class ServiceResolver implements ServiceResolverInterface
 
             if ($concrete !== $className) {
                 $args = array_merge($descriptor->getArguments(), $args);
-                return $this->resolveClass($concrete, $args);
+                return $this->resolveClass($concrete, $args, [...$aliasChain, $className]);
             }
         }
 

--- a/tests/integration/BindAndResolveTest.php
+++ b/tests/integration/BindAndResolveTest.php
@@ -95,6 +95,44 @@ final class BindAndResolveTest extends TestCase
      * @throws ContainerException
      * @throws NotFoundException
      */
+    public function testAliasChainResolvesFinalConcrete(): void
+    {
+        $container = new ArgonContainer();
+        $container->set(Foo::class, Bar::class);
+        $container->set(Bar::class, Silent::class);
+
+        $this->assertInstanceOf(Silent::class, $container->get(Foo::class));
+    }
+
+    public function testCircularAliasChainThrows(): void
+    {
+        $container = new ArgonContainer();
+        $container->set(Foo::class, Bar::class);
+        $container->set(Bar::class, Foo::class);
+
+        $this->expectException(ContainerException::class);
+        $this->expectExceptionMessageMatches('/Circular dependency detected.*Foo.*Bar.*Foo/s');
+
+        $container->get(Foo::class);
+    }
+
+    public function testLongCircularAliasChainThrows(): void
+    {
+        $container = new ArgonContainer();
+        $container->set(Foo::class, Bar::class);
+        $container->set(Bar::class, Silent::class);
+        $container->set(Silent::class, Foo::class);
+
+        $this->expectException(ContainerException::class);
+        $this->expectExceptionMessageMatches('/Circular dependency detected.*Foo.*Bar.*Silent.*Foo/s');
+
+        $container->get(Foo::class);
+    }
+
+    /**
+     * @throws ContainerException
+     * @throws NotFoundException
+     */
     public function testGettingUnboundClassWithoutConstructorSucceeds(): void
     {
         $container = new ArgonContainer();

--- a/tests/integration/Compiler/ContainerCompilerTest.php
+++ b/tests/integration/Compiler/ContainerCompilerTest.php
@@ -90,8 +90,7 @@ final class ContainerCompilerTest extends TestCase
         $file = self::compilerCacheFile($className);
 
         $compiler = new ContainerCompiler($container);
-        $effectiveStrictMode = $strictMode ?? $container->isStrictMode();
-        $compiler->compile($file, $className, $namespace, $effectiveStrictMode);
+        $compiler->compile($file, $className, $namespace, $strictMode);
 
         /** @psalm-suppress UnresolvableInclude */
         require_once $file;
@@ -635,6 +634,35 @@ final class ContainerCompilerTest extends TestCase
 
         $this->expectException(NotFoundException::class);
         $compiled->get(Logger::class);
+    }
+
+    /**
+     * @throws ContainerException
+     * @throws NotFoundException
+     * @throws ReflectionException
+     */
+    public function testCompiledContainerMirrorsRuntimeStrictModeWhenStrictModeIsOmitted(): void
+    {
+        $container = new ArgonContainer(strictMode: true);
+
+        $compiled = $this->compileAndLoadContainer($container, 'StrictMirrorsRuntime');
+
+        $this->expectException(NotFoundException::class);
+        $compiled->get(Logger::class);
+    }
+
+    /**
+     * @throws ContainerException
+     * @throws NotFoundException
+     * @throws ReflectionException
+     */
+    public function testCompiledContainerCanExplicitlyDisableStrictMode(): void
+    {
+        $container = new ArgonContainer(strictMode: true);
+
+        $compiled = $this->compileAndLoadContainer($container, 'ExplicitLenientFromStrict', strictMode: false);
+
+        $this->assertInstanceOf(Logger::class, $compiled->get(Logger::class));
     }
 
     /**

--- a/tests/unit/Container/ParameterStoreTest.php
+++ b/tests/unit/Container/ParameterStoreTest.php
@@ -24,6 +24,23 @@ final class ParameterStoreTest extends TestCase
         $this->assertSame('default', $store->get('missing', 'default'));
     }
 
+    public function testGetPreservesExplicitNullWhenDefaultIsProvided(): void
+    {
+        $store = new ParameterStore();
+        $store->set('feature.flag', null);
+
+        $this->assertTrue($store->has('feature.flag'));
+        $this->assertNull($store->get('feature.flag', 'fallback'));
+    }
+
+    public function testGetReturnsNullForExplicitNullWithoutDefault(): void
+    {
+        $store = new ParameterStore();
+        $store->set('feature.flag', null);
+
+        $this->assertNull($store->get('feature.flag'));
+    }
+
     public function testHasReturnsCorrectly(): void
     {
         $store = new ParameterStore();

--- a/tests/unit/Container/ServiceContainerTest.php
+++ b/tests/unit/Container/ServiceContainerTest.php
@@ -255,6 +255,20 @@ final class ServiceContainerTest extends TestCase
         $container->registerInterceptor('NotARealInterceptor');
     }
 
+    public function testRegisterInterceptorThrowsIfClassDoesNotImplementInterceptorContract(): void
+    {
+        $container = new ArgonContainer();
+
+        $this->expectException(ContainerException::class);
+        $this->expectExceptionMessage(
+            "[stdClass] Interceptor 'stdClass' must implement PreResolutionInterceptorInterface " .
+            'or PostResolutionInterceptorInterface.'
+        );
+
+        /** @psalm-suppress InvalidArgument */
+        $container->registerInterceptor(stdClass::class);
+    }
+
    /**
      * @throws ContainerException
      */


### PR DESCRIPTION
## Summary

- Preserve explicit `null` values in `ParameterStore::get()` when a default is provided.
- Reject invalid interceptor classes in `registerInterceptor()` instead of silently ignoring them.
- Detect circular class-alias chains during runtime resolution.
- Allow `ContainerCompiler::compile()` to distinguish omitted strict mode from explicit `false`.
- Prepare the `1.1.2` changelog section.

## Validation

- `vendor/bin/phpunit tests/unit/Container/ParameterStoreTest.php`
- `vendor/bin/phpunit tests/unit/Container/ServiceContainerTest.php`
- `vendor/bin/phpunit tests/integration/BindAndResolveTest.php`
- `vendor/bin/phpunit tests/integration/Compiler/ContainerCompilerTest.php`
- `composer check`

Closes #49
Closes #50
Closes #54
Closes #56