### PR TITLE
Improve container validation and invocation parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `maduser/argon` will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- Added runtime/compiled `ServiceInvoker` parity coverage for route-style invocation maps.
+
 ## [1.1.2] - 2026-05-21
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to `maduser/argon` will be documented in this file.
 
 - Added runtime/compiled `ServiceInvoker` parity coverage for route-style invocation maps.
 
+### Fixed
+
+- Container compilation now rejects `defineInvocation()` metadata for missing or non-public target methods before writing generated PHP.
+
 ## [1.1.2] - 2026-05-21
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to `maduser/argon` will be documented in this file.
 ### Fixed
 
 - Container compilation now rejects `defineInvocation()` metadata for missing or non-public target methods before writing generated PHP.
+- Factory-backed services now keep factory object resolution arguments separate from factory method arguments.
 
 ## [1.1.2] - 2026-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to `maduser/argon` will be documented in this file.
 
 - Container compilation now rejects `defineInvocation()` metadata for missing or non-public target methods before writing generated PHP.
 - Factory-backed services now keep factory object resolution arguments separate from factory method arguments.
+- Runtime and compiled service factories, closure bindings, and contextual closure bindings now reject non-object service results instead of casting them to objects.
 
 ## [1.1.2] - 2026-05-21
 

--- a/readme.md
+++ b/readme.md
@@ -198,6 +198,8 @@ TIP: you can wrap the parameter registry with your own "ConfigRepository" and im
 
 Use `factory()` to bind a service to a dedicated factory class.  
 The factory itself is resolved via the container and may define either an `__invoke()` method or a named method.
+Arguments bound to the product service, or passed to `get()` for the product service, are applied to the factory
+method only. If the factory object needs configuration, bind the factory class itself with its own arguments.
 
 ```php
 $container->set(ClockInterface::class)

--- a/src/Compiler/ContainerDescriptorValidator.php
+++ b/src/Compiler/ContainerDescriptorValidator.php
@@ -44,6 +44,8 @@ final class ContainerDescriptorValidator
             );
         }
 
+        $this->validateInvocations($id, $descriptor, $concrete);
+
         if ($descriptor->hasFactory()) {
             $this->validateFactory($id, $descriptor);
             return;
@@ -87,6 +89,42 @@ final class ContainerDescriptorValidator
                 $id,
                 sprintf('Factory method "%s" on class "%s" is not public.', $factoryMethod, $factoryClass)
             );
+        }
+    }
+
+    /**
+     * @param class-string $concrete
+     * @throws ContainerException
+     * @throws ReflectionException
+     */
+    private function validateInvocations(
+        string $id,
+        ServiceDescriptorInterface $descriptor,
+        string $concrete
+    ): void {
+        $invocations = $descriptor->getInvocationMap();
+
+        if ($invocations === []) {
+            return;
+        }
+
+        $reflection = new ReflectionClass($concrete);
+
+        foreach (array_keys($invocations) as $methodName) {
+            if (!$reflection->hasMethod($methodName)) {
+                throw ContainerException::fromServiceId(
+                    $id,
+                    sprintf('Invocation method "%s" not found on class "%s".', $methodName, $concrete)
+                );
+            }
+
+            $method = $reflection->getMethod($methodName);
+            if (!$method->isPublic()) {
+                throw ContainerException::fromServiceId(
+                    $id,
+                    sprintf('Invocation method "%s" on class "%s" is not public.', $methodName, $concrete)
+                );
+            }
         }
     }
 }

--- a/src/Compiler/CoreContainerGenerator.php
+++ b/src/Compiler/CoreContainerGenerator.php
@@ -24,6 +24,7 @@ final class CoreContainerGenerator
         $this->generateConstructor($class);
         $this->generateCoreProperties($class);
         $this->generateInterceptorMethods($class);
+        $this->generateObjectResultValidationMethod($class);
         $this->generateHasMethod($class);
         $this->generateGetMethod($class);
         $this->generateGetTaggedMethod($class);
@@ -107,6 +108,28 @@ final class CoreContainerGenerator
                 $resolved->intercept($instance);
             }
             return $instance;
+        PHP);
+    }
+
+    private function generateObjectResultValidationMethod(ClassType $class): void
+    {
+        $method = $class->addMethod('ensureObjectServiceResult');
+        $method->setPrivate()
+            ->setReturnType('object');
+
+        $method->addParameter('id')->setType('string');
+        $method->addParameter('value')->setType('mixed');
+        $method->addParameter('source')->setType('string');
+
+        $method->setBody(<<<'PHP'
+            if (!is_object($value)) {
+                throw ContainerException::fromServiceId(
+                    $id,
+                    sprintf('%s must return an object, got %s.', $source, get_debug_type($value))
+                );
+            }
+
+            return $value;
         PHP);
     }
 

--- a/src/Compiler/ServiceDefinitionGenerator.php
+++ b/src/Compiler/ServiceDefinitionGenerator.php
@@ -127,7 +127,7 @@ final class ServiceDefinitionGenerator
         if ($descriptor->isShared()) {
             $method->setBody(<<<PHP
                 if (\$this->{$singletonProperty} === null) {
-                    \$factory = \$this->get({$fqFactory}::class, \$args);
+                    \$factory = \$this->get({$fqFactory}::class);
                     \$this->{$singletonProperty} = \$this->applyPostInterceptors({$factoryInvocation});
                 } elseif (\$args !== []) {
                     throw ContainerException::fromServiceId(
@@ -139,7 +139,7 @@ final class ServiceDefinitionGenerator
             PHP);
         } else {
             $method->setBody(<<<PHP
-                \$factory = \$this->get({$fqFactory}::class, \$args);
+                \$factory = \$this->get({$fqFactory}::class);
                 return \$this->applyPostInterceptors({$factoryInvocation});
             PHP);
         }

--- a/src/Compiler/ServiceDefinitionGenerator.php
+++ b/src/Compiler/ServiceDefinitionGenerator.php
@@ -105,6 +105,7 @@ final class ServiceDefinitionGenerator
         $factoryInvocation = $methodReflection->isStatic()
             ? "{$fqFactory}::{$factoryMethod}(\n                    {$argString}\n                )"
             : "\$factory->{$factoryMethod}(\n                    {$argString}\n                )";
+        $factorySource = var_export(sprintf('Factory method "%s::%s()"', $factoryClass, $factoryMethod), true);
 
         $namespace->addUse($factoryClass);
 
@@ -128,7 +129,10 @@ final class ServiceDefinitionGenerator
             $method->setBody(<<<PHP
                 if (\$this->{$singletonProperty} === null) {
                     \$factory = \$this->get({$fqFactory}::class);
-                    \$this->{$singletonProperty} = \$this->applyPostInterceptors({$factoryInvocation});
+                    \$result = {$factoryInvocation};
+                    \$this->{$singletonProperty} = \$this->applyPostInterceptors(
+                        \$this->ensureObjectServiceResult({$serviceId}, \$result, {$factorySource})
+                    );
                 } elseif (\$args !== []) {
                     throw ContainerException::fromServiceId(
                         {$serviceId},
@@ -140,7 +144,10 @@ final class ServiceDefinitionGenerator
         } else {
             $method->setBody(<<<PHP
                 \$factory = \$this->get({$fqFactory}::class);
-                return \$this->applyPostInterceptors({$factoryInvocation});
+                \$result = {$factoryInvocation};
+                return \$this->applyPostInterceptors(
+                    \$this->ensureObjectServiceResult({$serviceId}, \$result, {$factorySource})
+                );
             PHP);
         }
 

--- a/src/Compiler/ServiceInvocationGenerator.php
+++ b/src/Compiler/ServiceInvocationGenerator.php
@@ -21,6 +21,10 @@ final class ServiceInvocationGenerator
     public function generate(ClassType $class): void
     {
         foreach ($this->container->getBindings() as $serviceId => $descriptor) {
+            if ($descriptor->shouldCompile() === false) {
+                continue;
+            }
+
             foreach ($descriptor->getInvocationMap() as $method => $args) {
                 $compiledMethodName = $this->buildMethodInvokerName($serviceId, $method);
                 $controllerFetch = "\$controller = \$this->get(" . var_export($serviceId, true) . ");";

--- a/src/ContextualResolver.php
+++ b/src/ContextualResolver.php
@@ -55,7 +55,7 @@ final readonly class ContextualResolver implements ContextualResolverInterface
         }
 
         if ($override instanceof Closure) {
-            return (object) $this->container->invoke($override);
+            return $this->ensureObjectResult($consumer, $dependency, $this->container->invoke($override));
         }
 
         return $this->container->get($override);
@@ -72,5 +72,21 @@ final readonly class ContextualResolver implements ContextualResolverInterface
     public function has(string $consumer, string $dependency): bool
     {
         return $this->bindings->has($consumer, $dependency);
+    }
+
+    private function ensureObjectResult(string $consumer, string $dependency, mixed $value): object
+    {
+        if (!is_object($value)) {
+            throw ContainerException::fromServiceId(
+                $dependency,
+                sprintf(
+                    'Contextual closure binding for "%s" must return an object, got %s.',
+                    $consumer,
+                    get_debug_type($value)
+                )
+            );
+        }
+
+        return $value;
     }
 }

--- a/src/ServiceResolver.php
+++ b/src/ServiceResolver.php
@@ -178,9 +178,13 @@ final class ServiceResolver implements ServiceResolverInterface
         $mergedArgs = array_merge($descriptor->getArguments(), $args);
         $orderedArgs = $this->resolveFactoryParameters($reflection->getParameters(), $mergedArgs, $id);
 
-        return $reflection->isStatic()
-            ? (object) (call_user_func([$factoryClass, $method], ...$orderedArgs))
-            : (object) (call_user_func([$factoryInstance, $method], ...$orderedArgs));
+        return $this->ensureObjectResult(
+            $id,
+            $reflection->isStatic()
+                ? call_user_func([$factoryClass, $method], ...$orderedArgs)
+                : call_user_func([$factoryInstance, $method], ...$orderedArgs),
+            sprintf('Factory method "%s::%s()"', $factoryClass, $method)
+        );
     }
 
     /**
@@ -359,7 +363,19 @@ final class ServiceResolver implements ServiceResolverInterface
             $reflection->getParameters()
         );
 
-        return (object) $closure(...$dependencies);
+        return $this->ensureObjectResult($contextId, $closure(...$dependencies), 'Closure binding');
+    }
+
+    private function ensureObjectResult(string $id, mixed $value, string $source): object
+    {
+        if (!is_object($value)) {
+            throw ContainerException::fromServiceId(
+                $id,
+                sprintf('%s must return an object, got %s.', $source, get_debug_type($value))
+            );
+        }
+
+        return $value;
     }
 
     /**

--- a/src/ServiceResolver.php
+++ b/src/ServiceResolver.php
@@ -161,7 +161,7 @@ final class ServiceResolver implements ServiceResolverInterface
             throw ContainerException::fromServiceId($id, 'Factory class not defined.');
         }
 
-        $factoryInstance = $this->resolve($factoryClass, $args);
+        $factoryInstance = $this->resolve($factoryClass);
 
         if (!method_exists($factoryInstance, $method)) {
             throw new ContainerException(sprintf(

--- a/tests/integration/BindAndResolveTest.php
+++ b/tests/integration/BindAndResolveTest.php
@@ -206,6 +206,17 @@ final class BindAndResolveTest extends TestCase
         $this->assertInstanceOf(\Tests\Integration\Mocks\Logger::class, $service->logger);
     }
 
+    public function testClosureBindingReturningNonObjectThrowsContainerException(): void
+    {
+        $container = new ArgonContainer();
+        $container->set('invalid.closure', fn(): string => 'not-a-service');
+
+        $this->expectException(ContainerException::class);
+        $this->expectExceptionMessage('Closure binding must return an object, got string.');
+
+        $container->get('invalid.closure');
+    }
+
     /**
      * @throws ContainerException
      * @throws NotFoundException

--- a/tests/integration/Compiler/ContainerCompilerTest.php
+++ b/tests/integration/Compiler/ContainerCompilerTest.php
@@ -27,6 +27,7 @@ use Tests\Integration\Compiler\Mocks\PrimitiveService;
 use Tests\Integration\Compiler\Mocks\RouteStyleController;
 use Tests\Integration\Compiler\Mocks\ServiceWithDependency;
 use Tests\Integration\Compiler\Mocks\SomeInterface;
+use Tests\Integration\Compiler\Mocks\StatefulDefaultValueFactory;
 use Tests\Integration\Compiler\Mocks\TestServiceWithMultipleParams;
 use Tests\Integration\Compiler\Mocks\WithOptionalInterface;
 use Tests\Integration\Compiler\Mocks\WithOptionalService;
@@ -1063,6 +1064,30 @@ final class ContainerCompilerTest extends TestCase
 
         $this->assertInstanceOf(DefaultValueService::class, $instance);
         $this->assertSame('runtime-supplied', $instance->label);
+    }
+
+    /**
+     * @throws ContainerException
+     * @throws ReflectionException
+     * @throws NotFoundException
+     */
+    public function testCompiledFactoryRuntimeArgumentsDoNotConfigureFactoryObject(): void
+    {
+        $container = new ArgonContainer();
+        $container->set(StatefulDefaultValueFactory::class, args: ['label' => 'factory-config']);
+        $container->set(DefaultValueService::class)
+            ->factory(StatefulDefaultValueFactory::class, 'create');
+
+        $compiled = $this->compileAndLoadContainer(
+            $container,
+            'testCompiledFactoryRuntimeArgumentsDoNotConfigureFactoryObject'
+        );
+
+        $service = $compiled->get(DefaultValueService::class, ['label' => 'product-runtime']);
+        $factory = $compiled->get(StatefulDefaultValueFactory::class);
+
+        $this->assertSame('factory-config:product-runtime', $service->label);
+        $this->assertInstanceOf(StatefulDefaultValueFactory::class, $factory);
     }
 
     /**

--- a/tests/integration/Compiler/ContainerCompilerTest.php
+++ b/tests/integration/Compiler/ContainerCompilerTest.php
@@ -1201,6 +1201,33 @@ final class ContainerCompilerTest extends TestCase
 
     /**
      * @throws ReflectionException
+     */
+    public function testCompilerValidatesInvocationMethodBeforeWritingFile(): void
+    {
+        $container = new ArgonContainer();
+        $container->set(RouteStyleController::class)->defineInvocation('missingMethod', []);
+
+        $output = self::compilerCacheFile('testCompilerValidatesInvocationMethodBeforeWritingFile');
+        $compiler = new ContainerCompiler($container);
+
+        try {
+            $compiler->compile(
+                $output,
+                'testCompilerValidatesInvocationMethodBeforeWritingFile',
+                'Tests\\Integration\\Compiler'
+            );
+            $this->fail('Expected invocation method validation to fail.');
+        } catch (ContainerException $exception) {
+            $this->assertStringContainsString(
+                'Invocation method "missingMethod" not found on class "' . RouteStyleController::class . '".',
+                $exception->getMessage()
+            );
+            $this->assertFileDoesNotExist($output);
+        }
+    }
+
+    /**
+     * @throws ReflectionException
      * @throws ContainerException
      */
     public function testCompilerSkipsClosureWhenMarkedSkipCompilation(): void

--- a/tests/integration/Compiler/ContainerCompilerTest.php
+++ b/tests/integration/Compiler/ContainerCompilerTest.php
@@ -9,6 +9,8 @@ use Maduser\Argon\Container\Compiler\ContainerCompiler;
 use Maduser\Argon\Container\Contracts\ServiceDescriptorInterface;
 use Maduser\Argon\Container\Exceptions\ContainerException;
 use Maduser\Argon\Container\Exceptions\NotFoundException;
+use Maduser\Argon\Container\Support\ReflectionUtils;
+use Maduser\Argon\Container\Support\ServiceInvoker;
 use PHPUnit\Framework\TestCase;
 use ReflectionException;
 use ReflectionMethod;
@@ -22,6 +24,7 @@ use Tests\Integration\Compiler\Mocks\LoggerInterceptor;
 use Tests\Integration\Compiler\Mocks\Mailer;
 use Tests\Integration\Compiler\Mocks\MailerFactory;
 use Tests\Integration\Compiler\Mocks\PrimitiveService;
+use Tests\Integration\Compiler\Mocks\RouteStyleController;
 use Tests\Integration\Compiler\Mocks\ServiceWithDependency;
 use Tests\Integration\Compiler\Mocks\SomeInterface;
 use Tests\Integration\Compiler\Mocks\TestServiceWithMultipleParams;
@@ -528,6 +531,69 @@ final class ContainerCompilerTest extends TestCase
         $result = $compiled->invoke([ServiceWithDependency::class, 'doSomething']);
 
         $this->assertSame('from-invoker', $result);
+    }
+
+    /**
+     * @throws ContainerException
+     * @throws NotFoundException
+     * @throws ReflectionException
+     */
+    public function testCompiledServiceInvokerMatchesRuntimeForRouteStyleInvocation(): void
+    {
+        $runtime = new ArgonContainer();
+        $runtime->set(Logger::class);
+        $runtime->set(RouteStyleController::class)
+            ->defineInvocation(
+                'show',
+                ReflectionUtils::getMethodParameters(RouteStyleController::class, 'show')
+            );
+
+        $compiled = $this->compileAndLoadContainer(
+            $runtime,
+            'testCompiledServiceInvokerMatchesRuntimeForRouteStyleInvocation'
+        );
+
+        $arguments = ['id' => '42'];
+        $runtimeResult = (new ServiceInvoker($runtime, RouteStyleController::class, 'show'))($arguments);
+        $compiledResult = (new ServiceInvoker($compiled, RouteStyleController::class, 'show'))($arguments);
+
+        $this->assertSame($runtimeResult, $compiledResult);
+        $this->assertSame([
+            'id' => '42',
+            'log' => 'route-hit',
+        ], $compiledResult);
+    }
+
+    /**
+     * @throws ContainerException
+     * @throws NotFoundException
+     * @throws ReflectionException
+     */
+    public function testCompiledServiceInvokerMatchesRuntimeForRouteStylePrimitiveCasting(): void
+    {
+        $runtime = new ArgonContainer();
+        $runtime->set(Logger::class);
+        $runtime->set(RouteStyleController::class)
+            ->defineInvocation(
+                'typed',
+                ReflectionUtils::getMethodParameters(RouteStyleController::class, 'typed')
+            );
+
+        $compiled = $this->compileAndLoadContainer(
+            $runtime,
+            'testCompiledServiceInvokerMatchesRuntimeForRouteStylePrimitiveCasting'
+        );
+
+        $arguments = ['id' => '42'];
+        $runtimeResult = (new ServiceInvoker($runtime, RouteStyleController::class, 'typed'))($arguments);
+        $compiledResult = (new ServiceInvoker($compiled, RouteStyleController::class, 'typed'))($arguments);
+
+        $this->assertSame($runtimeResult, $compiledResult);
+        $this->assertSame([
+            'id' => 42,
+            'ratio' => 1.5,
+            'log' => 'typed-route-hit',
+        ], $compiledResult);
     }
 
 

--- a/tests/integration/Compiler/ContainerCompilerTest.php
+++ b/tests/integration/Compiler/ContainerCompilerTest.php
@@ -1142,6 +1142,29 @@ final class ContainerCompilerTest extends TestCase
     /**
      * @throws ReflectionException
      * @throws ContainerException
+     * @throws NotFoundException
+     */
+    public function testCompiledFactoryReturningNonObjectThrowsContainerException(): void
+    {
+        $container = new ArgonContainer();
+        $container->set(DefaultValueService::class)
+            ->factory(MailerFactory::class, 'createString');
+
+        $compiled = $this->compileAndLoadContainer(
+            $container,
+            'testCompiledFactoryReturningNonObjectThrowsContainerException'
+        );
+
+        $this->expectException(ContainerException::class);
+        $this->expectExceptionMessage('Factory method "' . MailerFactory::class . '::createString()"');
+        $this->expectExceptionMessage('must return an object, got string');
+
+        $compiled->get(DefaultValueService::class);
+    }
+
+    /**
+     * @throws ReflectionException
+     * @throws ContainerException
      */
     public function testGenerateServiceMethodInvokerInjectsClassFromAtSymbol(): void
     {

--- a/tests/integration/Compiler/Mocks/MailerFactory.php
+++ b/tests/integration/Compiler/Mocks/MailerFactory.php
@@ -25,4 +25,9 @@ final class MailerFactory
     {
         return new DefaultValueService($label);
     }
+
+    public function createString(): string
+    {
+        return 'not-a-service';
+    }
 }

--- a/tests/integration/Compiler/Mocks/RouteStyleController.php
+++ b/tests/integration/Compiler/Mocks/RouteStyleController.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Compiler\Mocks;
+
+final class RouteStyleController
+{
+    public function show(Logger $logger, string $id): array
+    {
+        return [
+            'id' => $id,
+            'log' => $logger->log('route-hit'),
+        ];
+    }
+
+    public function typed(Logger $logger, int $id, float $ratio = 1.5): array
+    {
+        return [
+            'id' => $id,
+            'ratio' => $ratio,
+            'log' => $logger->log('typed-route-hit'),
+        ];
+    }
+}

--- a/tests/integration/Compiler/Mocks/StatefulDefaultValueFactory.php
+++ b/tests/integration/Compiler/Mocks/StatefulDefaultValueFactory.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Compiler\Mocks;
+
+final class StatefulDefaultValueFactory
+{
+    public function __construct(private readonly string $label)
+    {
+    }
+
+    public function create(string $label): DefaultValueService
+    {
+        return new DefaultValueService($this->label . ':' . $label);
+    }
+}

--- a/tests/integration/ContextualBindingTest.php
+++ b/tests/integration/ContextualBindingTest.php
@@ -92,4 +92,19 @@ final class ContextualBindingTest extends TestCase
 
         $this->assertInstanceOf(FileLogger::class, $a->logger);
     }
+
+    public function testContextualClosureBindingReturningNonObjectThrowsContainerException(): void
+    {
+        $container = new ArgonContainer();
+
+        $container->set(ServiceA::class);
+
+        $container->for(ServiceA::class)->set(LoggerInterface::class, fn(): string => 'not-a-service');
+
+        $this->expectException(ContainerException::class);
+        $this->expectExceptionMessage('Contextual closure binding for "' . ServiceA::class . '"');
+        $this->expectExceptionMessage('must return an object, got string.');
+
+        $container->get(ServiceA::class);
+    }
 }

--- a/tests/integration/FactoryIntegrationTest.php
+++ b/tests/integration/FactoryIntegrationTest.php
@@ -13,6 +13,7 @@ use ReflectionClass;
 use ReflectionException;
 use Tests\Integration\Mocks\Foo;
 use Tests\Integration\Mocks\FooFactory;
+use Tests\Integration\Mocks\InvalidFooFactory;
 use Tests\Integration\Mocks\InvokableFactory;
 use Tests\Integration\Mocks\Logger;
 use Tests\Integration\Mocks\StatefulFooFactory;
@@ -175,6 +176,21 @@ final class FactoryIntegrationTest extends TestCase
         $this->expectExceptionMessage("Factory method \"missingMethod\" not found on class");
 
         $this->container->set(Foo::class)->factory(FooFactory::class, 'missingMethod');
+
+        $this->container->get(Foo::class);
+    }
+
+    /**
+     * @throws ContainerException
+     * @throws NotFoundException
+     */
+    public function testFactoryReturningNonObjectThrowsContainerException(): void
+    {
+        $this->container->set(Foo::class)->factory(InvalidFooFactory::class, 'makeString');
+
+        $this->expectException(ContainerException::class);
+        $this->expectExceptionMessage('Factory method "' . InvalidFooFactory::class . '::makeString()"');
+        $this->expectExceptionMessage('must return an object, got string');
 
         $this->container->get(Foo::class);
     }

--- a/tests/integration/FactoryIntegrationTest.php
+++ b/tests/integration/FactoryIntegrationTest.php
@@ -15,6 +15,7 @@ use Tests\Integration\Mocks\Foo;
 use Tests\Integration\Mocks\FooFactory;
 use Tests\Integration\Mocks\InvokableFactory;
 use Tests\Integration\Mocks\Logger;
+use Tests\Integration\Mocks\StatefulFooFactory;
 use Tests\Integration\Mocks\StaticFooFactory;
 
 final class FactoryIntegrationTest extends TestCase
@@ -96,6 +97,45 @@ final class FactoryIntegrationTest extends TestCase
 
         $this->assertInstanceOf(Foo::class, $foo);
         $this->assertSame(Logger::class, $foo->label);
+    }
+
+    /**
+     * @throws ContainerException
+     * @throws NotFoundException
+     */
+    public function testFactoryRuntimeArgumentsDoNotConfigureFactoryObject(): void
+    {
+        $this->container->set(StatefulFooFactory::class, args: ['label' => 'factory-config']);
+        $this->container->set(Foo::class)
+            ->factory(StatefulFooFactory::class, 'make')
+            ->transient();
+
+        $foo = $this->container->get(Foo::class, ['label' => 'product-runtime']);
+        $factory = $this->container->get(StatefulFooFactory::class);
+
+        $this->assertSame('factory-config:product-runtime', $foo->label);
+        $this->assertSame('factory-config', $factory->label);
+        $this->assertSame(1, $factory->calls);
+    }
+
+    /**
+     * @throws ContainerException
+     * @throws NotFoundException
+     */
+    public function testSharedFactoryObjectIgnoresDifferentProductRuntimeArguments(): void
+    {
+        $this->container->set(StatefulFooFactory::class, args: ['label' => 'factory-config']);
+        $this->container->set(Foo::class)
+            ->factory(StatefulFooFactory::class, 'make')
+            ->transient();
+
+        $first = $this->container->get(Foo::class, ['label' => 'first-product']);
+        $second = $this->container->get(Foo::class, ['label' => 'second-product']);
+        $factory = $this->container->get(StatefulFooFactory::class);
+
+        $this->assertSame('factory-config:first-product', $first->label);
+        $this->assertSame('factory-config:second-product', $second->label);
+        $this->assertSame(2, $factory->calls);
     }
 
     /**

--- a/tests/integration/Mocks/InvalidFooFactory.php
+++ b/tests/integration/Mocks/InvalidFooFactory.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Mocks;
+
+final class InvalidFooFactory
+{
+    public function makeString(): string
+    {
+        return 'not-a-service';
+    }
+}

--- a/tests/integration/Mocks/StatefulFooFactory.php
+++ b/tests/integration/Mocks/StatefulFooFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Mocks;
+
+final class StatefulFooFactory
+{
+    public int $calls = 0;
+
+    public function __construct(public readonly string $label)
+    {
+    }
+
+    public function make(string $label): Foo
+    {
+        $this->calls++;
+
+        return new Foo($this->label . ':' . $label);
+    }
+}

--- a/tests/unit/Container/Compiler/ContainerDescriptorValidatorTest.php
+++ b/tests/unit/Container/Compiler/ContainerDescriptorValidatorTest.php
@@ -11,6 +11,7 @@ use Maduser\Argon\Container\Exceptions\ContainerException;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use Tests\Unit\Container\Compiler\Stubs\PrivateFactory;
+use Tests\Unit\Container\Compiler\Stubs\ServiceWithTypedMethods;
 
 final class ContainerDescriptorValidatorTest extends TestCase
 {
@@ -22,6 +23,7 @@ final class ContainerDescriptorValidatorTest extends TestCase
         $descriptor->method('hasFactory')->willReturn(true);
         $descriptor->method('getFactoryClass')->willReturn(null);
         $descriptor->method('getFactoryMethod')->willReturn('__invoke');
+        $descriptor->method('getInvocationMap')->willReturn([]);
 
         $this->expectException(ContainerException::class);
         $this->expectExceptionMessage('Factory class not defined.');
@@ -37,6 +39,7 @@ final class ContainerDescriptorValidatorTest extends TestCase
         $descriptor->method('hasFactory')->willReturn(true);
         $descriptor->method('getFactoryClass')->willReturn(PrivateFactory::class);
         $descriptor->method('getFactoryMethod')->willReturn('create');
+        $descriptor->method('getInvocationMap')->willReturn([]);
 
         $this->expectException(ContainerException::class);
         $this->expectExceptionMessage(
@@ -44,6 +47,36 @@ final class ContainerDescriptorValidatorTest extends TestCase
         );
 
         (new ContainerDescriptorValidator())->validate($this->containerWithDescriptor($descriptor));
+    }
+
+    public function testInvocationMethodMustExist(): void
+    {
+        $container = new ArgonContainer();
+        $container->set(ServiceWithTypedMethods::class)
+            ->defineInvocation('missingMethod', []);
+
+        $this->expectException(ContainerException::class);
+        $this->expectExceptionMessage(sprintf(
+            'Invocation method "missingMethod" not found on class "%s".',
+            ServiceWithTypedMethods::class
+        ));
+
+        (new ContainerDescriptorValidator())->validate($container);
+    }
+
+    public function testInvocationMethodMustBePublic(): void
+    {
+        $container = new ArgonContainer();
+        $container->set(PrivateFactory::class)
+            ->defineInvocation('create', []);
+
+        $this->expectException(ContainerException::class);
+        $this->expectExceptionMessage(sprintf(
+            'Invocation method "create" on class "%s" is not public.',
+            PrivateFactory::class
+        ));
+
+        (new ContainerDescriptorValidator())->validate($container);
     }
 
     private function containerWithDescriptor(ServiceDescriptorInterface $descriptor): ArgonContainer

--- a/tests/unit/Container/Compiler/ServiceInvocationGeneratorTest.php
+++ b/tests/unit/Container/Compiler/ServiceInvocationGeneratorTest.php
@@ -54,13 +54,12 @@ final class ServiceInvocationGeneratorTest extends TestCase
         self::assertStringContainsString("(float) \$mergedArgs['ratio']", $body);
     }
 
-    public function testGenerateSkipsPrimitiveCastsForNonClassAndMissingMethod(): void
+    public function testGenerateSkipsDescriptorsExcludedFromCompilation(): void
     {
         $container = new ArgonContainer();
         $container->set('closure.service', static fn() => new ServiceWithTypedMethods())
+            ->skipCompilation()
             ->defineInvocation('handle', ['id' => 1]);
-        $container->set(ServiceWithTypedMethods::class)
-            ->defineInvocation('undefinedMethod', []);
 
         $generator = new ServiceInvocationGenerator($container);
         $class = new ClassType('CompiledContainer');
@@ -70,23 +69,7 @@ final class ServiceInvocationGeneratorTest extends TestCase
         $closureInvokerName = 'invoke_'
             . StringHelper::sanitizeIdentifier('closure.service')
             . '__handle';
-        $missingInvokerName = 'invoke_'
-            . StringHelper::sanitizeIdentifier(ServiceWithTypedMethods::class)
-            . '__undefinedMethod';
 
-        self::assertTrue($class->hasMethod($closureInvokerName));
-        self::assertTrue($class->hasMethod($missingInvokerName));
-        $closureMethod = $class->getMethod($closureInvokerName);
-        $missingMethod = $class->getMethod($missingInvokerName);
-
-        $escapedServiceClass = str_replace('\\', '\\\\', ServiceWithTypedMethods::class);
-
-        $closureBody = $closureMethod->getBody();
-        self::assertStringNotContainsString('(int)', $closureBody);
-        self::assertStringNotContainsString('(float)', $closureBody);
-
-        $missingBody = $missingMethod->getBody();
-        self::assertStringContainsString("\$controller = \$this->get('{$escapedServiceClass}');", $missingBody);
-        self::assertStringContainsString("\$controller->undefinedMethod(...\$mergedArgs);", $missingBody);
+        self::assertFalse($class->hasMethod($closureInvokerName));
     }
 }

--- a/tests/unit/Container/Compiler/ServiceInvocationGeneratorTest.php
+++ b/tests/unit/Container/Compiler/ServiceInvocationGeneratorTest.php
@@ -72,4 +72,42 @@ final class ServiceInvocationGeneratorTest extends TestCase
 
         self::assertFalse($class->hasMethod($closureInvokerName));
     }
+
+    public function testGenerateOmitsPrimitiveCastsForClosureConcrete(): void
+    {
+        $container = new ArgonContainer();
+        $container->set('closure.service', static fn() => new ServiceWithTypedMethods())
+            ->defineInvocation('handle', ['id' => 1]);
+
+        $generator = new ServiceInvocationGenerator($container);
+        $class = new ClassType('CompiledContainer');
+
+        $generator->generate($class);
+
+        $method = $class->getMethod('invoke_closure_service__handle');
+
+        self::assertStringNotContainsString('(int)', $method->getBody());
+        self::assertStringContainsString('return $controller->handle(...$mergedArgs);', $method->getBody());
+    }
+
+    public function testGenerateOmitsPrimitiveCastsForUnknownInvocationMethod(): void
+    {
+        $container = new ArgonContainer();
+        $container->set(ServiceWithTypedMethods::class)
+            ->defineInvocation('missing', ['id' => 1]);
+
+        $generator = new ServiceInvocationGenerator($container);
+        $class = new ClassType('CompiledContainer');
+
+        $generator->generate($class);
+
+        $methodName = 'invoke_'
+            . StringHelper::sanitizeIdentifier(ServiceWithTypedMethods::class)
+            . '__missing';
+
+        $method = $class->getMethod($methodName);
+
+        self::assertStringNotContainsString('(int)', $method->getBody());
+        self::assertStringContainsString('return $controller->missing(...$mergedArgs);', $method->getBody());
+    }
 }

--- a/tests/unit/Container/ContextualResolverTest.php
+++ b/tests/unit/Container/ContextualResolverTest.php
@@ -54,12 +54,14 @@ final class ContextualResolverTest extends TestCase
     public function testResolveReturnsClosureResult(): void
     {
         $closure = fn(): object => new stdClass();
+        $object = new stdClass();
 
         $this->registry->method('get')->with('Consumer', 'Dep')->willReturn($closure);
+        $this->container->expects($this->once())->method('invoke')->with($closure)->willReturn($object);
 
         $result = $this->resolver->resolve('Consumer', 'Dep');
 
-        $this->assertInstanceOf(stdClass::class, $result);
+        $this->assertSame($object, $result);
     }
 
     /**


### PR DESCRIPTION
## Summary

- add runtime/compiled invocation parity coverage for route-style `ServiceInvoker` usage
- validate compiled invocation targets before generated PHP is written
- keep factory object construction arguments separate from factory method/runtime arguments
- reject non-object results from service factories, closure bindings, and contextual closure bindings instead of casting them
- update `CHANGELOG.md` for the completed tickets

Closes #51
Closes #52
Closes #53
Closes #55

## Validation

- `composer check`